### PR TITLE
Refactor 'coinName' out of Wallet

### DIFF
--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/AlgorandWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/AlgorandWallet.java
@@ -37,14 +37,14 @@ public class AlgorandWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change != null) {
-            logWarning(CHANGE, coinName, change);
+            logWarning(CHANGE, change);
         }
         if (addressIndex != null) {
-            logWarning(INDEX, coinName, addressIndex);
+            logWarning(INDEX, addressIndex);
         }
 
         return getAddress(account);

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/AvalancheWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/AvalancheWallet.java
@@ -36,13 +36,13 @@ public class AvalancheWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account != null) {
-            logWarning(ACCOUNT, coinName, account);
+            logWarning(ACCOUNT, account);
         }
         if (change != null) {
-            logWarning(CHANGE, coinName, change);
+            logWarning(CHANGE, change);
         }
         if (addressIndex == null) {
-            logMissing(INDEX, coinName);
+            logMissing(INDEX);
             addressIndex = 0;
         }
 

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/BitcoinWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/BitcoinWallet.java
@@ -31,15 +31,15 @@ public class BitcoinWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change == null) {
-            logMissing(CHANGE, coinName);
+            logMissing(CHANGE);
             change = 0;
         }
         if (addressIndex == null) {
-            logMissing(INDEX, coinName);
+            logMissing(INDEX);
             addressIndex = 0;
         }
 

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/DogecoinWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/DogecoinWallet.java
@@ -31,15 +31,15 @@ public class DogecoinWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change == null) {
-            logMissing(CHANGE, coinName);
+            logMissing(CHANGE);
             change = 0;
         }
         if (addressIndex == null) {
-            logMissing(INDEX, coinName);
+            logMissing(INDEX);
             addressIndex = 0;
         }
 

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/EthereumWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/EthereumWallet.java
@@ -26,13 +26,13 @@ public class EthereumWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account != null) {
-            logWarning(ACCOUNT, coinName, account);
+            logWarning(ACCOUNT, account);
         }
         if (change != null) {
-            logWarning(CHANGE, coinName, change);
+            logWarning(CHANGE, change);
         }
         if (addressIndex == null) {
-            logMissing(INDEX, coinName);
+            logMissing(INDEX);
             addressIndex = 0;
         }
 

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/LitecoinWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/LitecoinWallet.java
@@ -31,15 +31,15 @@ public class LitecoinWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change == null) {
-            logMissing(CHANGE, coinName);
+            logMissing(CHANGE);
             change = 0;
         }
         if (addressIndex == null) {
-            logMissing(INDEX, coinName);
+            logMissing(INDEX);
             addressIndex = 0;
         }
 

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/MoneroWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/MoneroWallet.java
@@ -36,14 +36,14 @@ public class MoneroWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change != null) {
-            logWarning(CHANGE, coinName, change);
+            logWarning(CHANGE, change);
         }
         if (addressIndex != null) {
-            logWarning(INDEX, coinName, addressIndex);
+            logWarning(INDEX, addressIndex);
         }
 
         return getAddress(account);

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/RippleWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/RippleWallet.java
@@ -33,14 +33,14 @@ public class RippleWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change != null) {
-            logWarning(CHANGE, coinName, change);
+            logWarning(CHANGE, change);
         }
         if (addressIndex != null) {
-            logWarning(INDEX, coinName, addressIndex);
+            logWarning(INDEX, addressIndex);
         }
 
         return getAddress(account);

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/StellarWallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/StellarWallet.java
@@ -25,14 +25,14 @@ public class StellarWallet extends Wallet {
     public Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex) {
 
         if (account == null) {
-            logMissing(ACCOUNT, coinName);
+            logMissing(ACCOUNT);
             account = 0;
         }
         if (change != null) {
-            logWarning(CHANGE, coinName, change);
+            logWarning(CHANGE, change);
         }
         if (addressIndex != null) {
-            logWarning(INDEX, coinName, addressIndex);
+            logWarning(INDEX, addressIndex);
         }
 
         return getAddress(account);

--- a/core/src/main/java/com/ashelkov/wallet/bip/wallet/Wallet.java
+++ b/core/src/main/java/com/ashelkov/wallet/bip/wallet/Wallet.java
@@ -9,11 +9,9 @@ import com.ashelkov.wallet.bip.address.Bip44Address;
 public abstract class Wallet {
 
     protected final Coin coin;
-    protected final String coinName;
 
     protected Wallet(Coin coin) {
         this.coin = coin;
-        this.coinName = coin.toString();
     }
 
     protected static final Logger logger = LoggerFactory.getLogger(Wallet.class);
@@ -24,12 +22,20 @@ public abstract class Wallet {
     protected static final String CHANGE = "change";
     protected static final String INDEX = "address index";
 
-    protected static void logWarning(String path, String coin, int val) {
+    private static void logWarning(String path, String coin, int val) {
         logger.warn(String.format(UNUSED_BIP_PATH_MSG_BASE, path, coin, val));
     }
 
-    protected static void logMissing(String path, String coin) {
+    private static void logMissing(String path, String coin) {
         logger.info(String.format(MISSING_BIP_PATH_MSG_BASE, path, coin));
+    }
+
+    protected void logWarning(String path, int val) {
+        logWarning(path, coin.toString(), val);
+    }
+
+    protected void logMissing(String path) {
+        logMissing(path, coin.toString());
     }
 
     public abstract Bip44Address getSpecificAddress(Integer account, Integer change, Integer addressIndex);


### PR DESCRIPTION
The `coinName` member in `Wallet` and derived classes was only being used to pass the name of the coin to the static logging functions. This PR changes the logging interface to remove the need for `coinName`.