### PR TITLE
dx: add bin/new script

### DIFF
--- a/bin/new
+++ b/bin/new
@@ -1,0 +1,3 @@
+COIN=$1
+WALLET_ID=$(date +%s)
+bin/owg-local.sh -o ~/.wallets/$COIN/$WALLET_ID -p cold -c $COIN


### PR DESCRIPTION
A simple helper script to generate a cold wallet.

*Syntax*
```
bin/new [coin supported by OWG]
```

*Example*
```sh
bin/new ETH
# ...
INFO: Attempting to save wallet to file '/home/me/.wallets/ETH/1638495048'
```