### PR TITLE
Refactor out "cold"/"hot" terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Upcoming
 ### Short-term
-- Refactor terminology from "cold & hot" to "solo & multi"
 - Add coin subcommands for "solo" wallets
   - XRP: option to use secp256k1 or ed25519
   - XMR: view/spend keys
@@ -36,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to print output to console instead of file
 - Option to output private/public keys
 ### Changed
-- Default XRP address  uses curve secp256k1 instead of ed25519
-- CLI now uses commands instead of options to determine the type of wallet to create (cold/hot)
+- Default XRP address uses curve secp256k1 instead of ed25519
+- Replaced CLI "cold"/"hot" options with "solo"/"multi" commands
 - Default file name
 - Output file no longer overwrites existing file by default
 

--- a/README.md
+++ b/README.md
@@ -58,20 +58,29 @@ Usage: <main class> [options] [command] [command options]
       Number of bits of entropy for randomly generated seed (must be 128-256 & 
       multiple of 32)
       Default: 256
+    -f, --format
+      Generated wallet output format
+      Default: WALLET
+      Possible Values: [CONSOLE, SECURE_CONSOLE, WALLET]
     -h, --help
       Show this usage details page
     -p, --mnemonic-password
       Password for mnemonic used to generate wallet master key
-    -o, --output-location
-      Output directory or path for wallet file
+    -o, --output-file
+      Directory or path for output files
       Default: /home/ashelkov/.wallets
     -w, --overwrite
-      Overwrite wallet if already exists?
+      Overwrite wallet if already exists
       Default: false
-
+    -K, --priv
+      Output the private keys for each generated address
+      Default: false
+    -k, --pub
+      Output the public keys for each generated address
+      Default: false
   Commands:
-    cold      Generate a wallet for a single cryptocurrency
-      Usage: cold [options]
+    solo      Generate a wallet for a single cryptocurrency
+      Usage: solo [options]
         Options:
           -a, --account
             BIP 44 account field for address
@@ -81,37 +90,37 @@ Usage: <main class> [options] [command] [command options]
             BIP 44 change field for address
         * -c, --coin
             Crypto currency code of coin for which to generate wallet
-            Possible Values: [BTC, LTC, DOGE, ETH, XMR, XRP, XLM, ALGO, AVAX]
+            Possible Values: [BTC, LTC, DOGE, ETH, XMR, XRP, XLM, ALGO, ERG, HNS, AVAX]
           -n, --num-addresses
             Number of addresses to generate
             Default: 1
 
-    hot      Generate a wallet for multiple cryptocurrencies
-      Usage: hot
+    multi      Generate a wallet for multiple cryptocurrencies
+      Usage: multi
 ```
 
 #### Examples
 
-Generate a cold wallet for the first 10 Dogecoin addresses, using a custom mnemonic and password:
+Generate a wallet file for the first 10 Dogecoin addresses using a custom mnemonic, custom password, and the default
+output directory:
 
 ```shell
-bin/release.sh \
--o ~/.wallets/cold/doge.wal \
+./bin/release.sh \
 -m \
 -p \
-cold \
+solo \
 --coin=DOGE \
 -n=10
 ```
 
-Generate a cold wallet for Bitcoin addresses `m/84'/0'/2'/1'/3'` and `m/84'/0'/2'/1'/4'` using a random 12-word mnemonic
-and no password:
+Generate a wallet file for the Bitcoin addresses `m/84'/0'/2'/1'/3'` and `m/84'/0'/2'/1'/4'` using a random 12-word
+mnemonic, no password, and a custom output directory:
 
 ```shell
-bin/release.sh \
--o ~/.wallets/cold/btc.wal \
+./bin/release.sh \
+-o ~/btc/BTC-1.wal \
 -e 128 \
-cold \
+solo \
 -c=BTC \
 --account=2 \
 --change=1 \
@@ -119,22 +128,21 @@ cold \
 --num-addresses=2
 ```
 
-Generate a hot wallet file containing the default address for every supported coin:
+Generate a multi-coin wallet containing the default address for every supported coin using a random 24-word mnemonic, no
+password, and output the results to the console:
 
 ```shell
-bin/release.sh \
--o ~/.wallets/hot.wal \
--m \
--p \
-hot
+./bin/release.sh \
+-f CONSOLE \
+multi
 ```
 
 ### Output
 
 This tool generates the mnemonic, the specified address(es), and its/their BIP 44/84 path(s). Unless a custom name and
 location are specified, the wallet will be written to one of the locations specified below, determined by operating
-system. The name of the file will be `{coin}.wal`, where `{coin}` is the cryptocurrency code of the wallet, if its a
-cold wallet. The name of the file will be `hot.wal` if its a hot wallet.
+system. The name of the file will be `{coin}.wal`, where `{coin}` is the cryptocurrency code of the wallet, if it's a
+single-coin wallet. The name of the file will be `multi.wal` if it's a multi-coin wallet.
 
 #### Linux
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,12 @@
 allprojects {
     apply plugin: 'eclipse'
     apply plugin: 'idea'
+
+    tasks.withType(JavaCompile).all { JavaCompile compile ->
+        compile.options.compilerArgs = [
+                "-Xlint:deprecation"
+        ]
+    }
 }
 
 subprojects {
@@ -51,7 +57,6 @@ subprojects {
         }
     }
 
-    // This task allows to get the dependencies from all the sub-project from the main photon-ml directory
-    // (otherwise, you have to change to each sub-project directory to get its dependencies)
+    // This task allows to get the dependencies for all the sub-projects from the main directory
     task allDeps(type: DependencyReportTask) {}
 }

--- a/core/src/main/java/com/ashelkov/owg/Application.java
+++ b/core/src/main/java/com/ashelkov/owg/Application.java
@@ -11,8 +11,8 @@ import org.web3j.crypto.MnemonicUtils;
 import com.ashelkov.owg.bip.Coin;
 import com.ashelkov.owg.io.Params;
 import com.ashelkov.owg.util.Utils;
-import com.ashelkov.owg.wallet.ColdWallet;
-import com.ashelkov.owg.wallet.HotWallet;
+import com.ashelkov.owg.wallet.SingleCoinWallet;
+import com.ashelkov.owg.wallet.MultiCoinWallet;
 import com.ashelkov.owg.wallet.Wallet;
 import com.ashelkov.owg.wallet.generators.WalletGenerator;
 import com.ashelkov.owg.wallet.generators.WalletGeneratorFactory;
@@ -24,9 +24,9 @@ public final class Application {
 
     private Application() {}
 
-    private static HotWallet generateHotWallet(byte[] seed) {
+    private static MultiCoinWallet generateMultiWallet(byte[] seed) {
 
-        List<ColdWallet> subwallets = new ArrayList<>(Coin.values().length);
+        List<SingleCoinWallet> subWallets = new ArrayList<>(Coin.values().length);
 
         for (Coin coin : Coin.values()) {
             WalletGenerator walletGenerator = WalletGeneratorFactory.getGenerator(
@@ -34,10 +34,10 @@ public final class Application {
                     seed,
                     params.isGenPrivKey(),
                     params.isGenPubKey());
-            subwallets.add(walletGenerator.generateDefaultWallet());
+            subWallets.add(walletGenerator.generateDefaultWallet());
         }
 
-        return new HotWallet(subwallets);
+        return new MultiCoinWallet(subWallets);
     }
 
     public static void main(String[] args) {
@@ -96,7 +96,7 @@ public final class Application {
         Wallet wallet;
 
         switch (params.getCommand()) {
-            case Params.COMMAND_COLD -> {
+            case Params.COMMAND_SOLO -> {
 
                     WalletGenerator walletGenerator = WalletGeneratorFactory.getGenerator(
                             params.getCoin(),
@@ -110,8 +110,8 @@ public final class Application {
                         params.getNumAddresses());
                 }
 
-            case Params.COMMAND_HOT ->
-                wallet = generateHotWallet(seedFromMnemonic);
+            case Params.COMMAND_MULTI ->
+                wallet = generateMultiWallet(seedFromMnemonic);
 
             default ->
                 throw new IllegalArgumentException("Unrecognized command");

--- a/core/src/main/java/com/ashelkov/owg/io/Params.java
+++ b/core/src/main/java/com/ashelkov/owg/io/Params.java
@@ -11,8 +11,8 @@ import com.beust.jcommander.converters.PathConverter;
 import org.apache.commons.lang3.SystemUtils;
 
 import com.ashelkov.owg.bip.Coin;
-import com.ashelkov.owg.io.command.ColdCommand;
-import com.ashelkov.owg.io.command.HotCommand;
+import com.ashelkov.owg.io.command.SoloCommand;
+import com.ashelkov.owg.io.command.MultiCommand;
 import com.ashelkov.owg.io.conversion.OutputFormatConverter;
 import com.ashelkov.owg.io.storage.OutputFormat;
 import com.ashelkov.owg.io.storage.Writer;
@@ -126,11 +126,11 @@ final public class Params {
     // CLI Commands
     //
 
-    private static ColdCommand coldCommand = ColdCommand.getInstance();
-    private static HotCommand hotCommand = HotCommand.getInstance();
+    private static SoloCommand soloCommand = SoloCommand.getInstance();
+    private static MultiCommand multiCommand = MultiCommand.getInstance();
 
-    public static final String COMMAND_COLD = "cold";
-    public static final String COMMAND_HOT = "hot";
+    public static final String COMMAND_SOLO = "solo";
+    public static final String COMMAND_MULTI = "multi";
 
     //
     // Singleton Setup
@@ -147,8 +147,8 @@ final public class Params {
             commander = JCommander
                     .newBuilder()
                     .addObject(singleton)
-                    .addCommand(COMMAND_COLD, coldCommand)
-                    .addCommand(COMMAND_HOT, hotCommand)
+                    .addCommand(COMMAND_SOLO, soloCommand)
+                    .addCommand(COMMAND_MULTI, multiCommand)
                     .build();
         }
 
@@ -215,23 +215,23 @@ final public class Params {
     }
 
     public Coin getCoin() {
-        return coldCommand.getCoin();
+        return soloCommand.getCoin();
     }
 
     public Integer getAccount() {
-        return coldCommand.getAccount();
+        return soloCommand.getAccount();
     }
 
     public Integer getChange() {
-        return coldCommand.getChange();
+        return soloCommand.getChange();
     }
 
     public Integer getIndex() {
-        return coldCommand.getIndex();
+        return soloCommand.getIndex();
     }
 
     public Integer getNumAddresses() {
-        return coldCommand.getNumAddresses();
+        return soloCommand.getNumAddresses();
     }
 
     //

--- a/core/src/main/java/com/ashelkov/owg/io/command/MultiCommand.java
+++ b/core/src/main/java/com/ashelkov/owg/io/command/MultiCommand.java
@@ -6,19 +6,19 @@ import com.beust.jcommander.Parameters;
  *
  */
 @Parameters(commandDescription = "Generate a wallet for multiple cryptocurrencies")
-final public class HotCommand {
+final public class MultiCommand {
 
     //
     // Singleton Setup
     //
 
-    private static HotCommand singleton = null;
+    private static MultiCommand singleton = null;
 
-    private HotCommand() {}
+    private MultiCommand() {}
 
-    public static HotCommand getInstance() {
+    public static MultiCommand getInstance() {
         if (singleton == null) {
-            singleton = new HotCommand();
+            singleton = new MultiCommand();
         }
 
         return singleton;

--- a/core/src/main/java/com/ashelkov/owg/io/command/SoloCommand.java
+++ b/core/src/main/java/com/ashelkov/owg/io/command/SoloCommand.java
@@ -14,7 +14,7 @@ import com.ashelkov.owg.io.validation.*;
 @Parameters(
         separators = "=",
         commandDescription = "Generate a wallet for a single cryptocurrency")
-final public class ColdCommand {
+final public class SoloCommand {
 
     //
     // CLI Parameter Constants
@@ -78,13 +78,13 @@ final public class ColdCommand {
     // Singleton Setup
     //
 
-    private static ColdCommand singleton = null;
+    private static SoloCommand singleton = null;
 
-    private ColdCommand() {}
+    private SoloCommand() {}
 
-    public static ColdCommand getInstance() {
+    public static SoloCommand getInstance() {
         if (singleton == null) {
-            singleton = new ColdCommand();
+            singleton = new SoloCommand();
         }
 
         return singleton;

--- a/core/src/main/java/com/ashelkov/owg/wallet/AlgorandWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/AlgorandWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class AlgorandWallet extends ColdWallet {
+public class AlgorandWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.ALGO;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/AvalancheWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/AvalancheWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class AvalancheWallet extends ColdWallet {
+public class AvalancheWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.AVAX;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/BitcoinWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/BitcoinWallet.java
@@ -8,7 +8,7 @@ import com.ashelkov.owg.bip.Coin;
 
 import static com.ashelkov.owg.bip.Constants.BIP84_PURPOSE;
 
-public class BitcoinWallet extends ColdWallet {
+public class BitcoinWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.BTC;
     public static final int PURPOSE = BIP84_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/DogecoinWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/DogecoinWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class DogecoinWallet extends ColdWallet {
+public class DogecoinWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.DOGE;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/ErgoWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/ErgoWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class ErgoWallet extends ColdWallet {
+public class ErgoWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.ERG;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/EthereumWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/EthereumWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class EthereumWallet extends ColdWallet {
+public class EthereumWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.ETH;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/HandshakeWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/HandshakeWallet.java
@@ -8,7 +8,7 @@ import com.ashelkov.owg.bip.Coin;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class HandshakeWallet extends ColdWallet {
+public class HandshakeWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.HNS;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/LitecoinWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/LitecoinWallet.java
@@ -8,7 +8,7 @@ import com.ashelkov.owg.bip.Coin;
 
 import static com.ashelkov.owg.bip.Constants.BIP84_PURPOSE;
 
-public class LitecoinWallet extends ColdWallet {
+public class LitecoinWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.LTC;
     public static final int PURPOSE = BIP84_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/MoneroWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/MoneroWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class MoneroWallet extends ColdWallet {
+public class MoneroWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.XMR;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/MultiCoinWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/MultiCoinWallet.java
@@ -2,14 +2,14 @@ package com.ashelkov.owg.wallet;
 
 import java.util.List;
 
-public class HotWallet extends Wallet {
+public class MultiCoinWallet extends Wallet {
 
-    private static final String ID = "hot";
+    private static final String ID = "multi";
 
-    protected final List<ColdWallet> subwallets;
+    protected final List<SingleCoinWallet> subWallets;
 
-    public HotWallet(List<ColdWallet> subwallets) {
-        this.subwallets = subwallets;
+    public MultiCoinWallet(List<SingleCoinWallet> subWallets) {
+        this.subWallets = subWallets;
     }
 
     @Override
@@ -22,7 +22,7 @@ public class HotWallet extends Wallet {
 
         StringBuilder result = new StringBuilder();
 
-        for (ColdWallet wallet : subwallets) {
+        for (SingleCoinWallet wallet : subWallets) {
             result.append("\n\n");
             result.append(wallet.toString());
         }

--- a/core/src/main/java/com/ashelkov/owg/wallet/SingleCoinWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/SingleCoinWallet.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 import com.ashelkov.owg.address.BIP44Address;
 
-public abstract class ColdWallet extends Wallet {
+public abstract class SingleCoinWallet extends Wallet {
 
     protected final List<BIP44Address> addresses;
 
-    protected ColdWallet(List<BIP44Address> addresses) {
+    protected SingleCoinWallet(List<BIP44Address> addresses) {
         this.addresses = addresses;
     }
 }

--- a/core/src/main/java/com/ashelkov/owg/wallet/StellarWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/StellarWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class StellarWallet extends ColdWallet {
+public class StellarWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.XLM;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/XRPWallet.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/XRPWallet.java
@@ -7,7 +7,7 @@ import com.ashelkov.owg.address.BIP44Address;
 
 import static com.ashelkov.owg.bip.Constants.BIP44_PURPOSE;
 
-public class XRPWallet extends ColdWallet {
+public class XRPWallet extends SingleCoinWallet {
 
     public static final Coin COIN = Coin.XRP;
     public static final int PURPOSE = BIP44_PURPOSE;

--- a/core/src/main/java/com/ashelkov/owg/wallet/generators/AvalancheWalletGenerator.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/generators/AvalancheWalletGenerator.java
@@ -90,6 +90,7 @@ public class AvalancheWalletGenerator extends WalletGenerator {
         addressBuilder.append(CHAIN_DELIMITER);
         addressBuilder.append(
                 Bech32.encode(
+                        Bech32.Encoding.BECH32,
                         BECH32_HRP,
                         EncodingUtils.to5BitBytesSafe(
                                 Hash.sha256hash160(

--- a/core/src/main/java/com/ashelkov/owg/wallet/generators/BitcoinWalletGenerator.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/generators/BitcoinWalletGenerator.java
@@ -106,7 +106,7 @@ public class BitcoinWalletGenerator extends WalletGenerator {
         unencodedAddressWithWitness[0] = WITNESS_VERSION;
         System.arraycopy(unencodedAddress, 0, unencodedAddressWithWitness, 1, unencodedAddress.length);
 
-        String address = Bech32.encode(BECH32_HRP, unencodedAddressWithWitness);
+        String address = Bech32.encode(Bech32.Encoding.BECH32, BECH32_HRP, unencodedAddressWithWitness);
 
         String privKeyText = null;
         String pubKeyText = null;

--- a/core/src/main/java/com/ashelkov/owg/wallet/generators/HandshakeWalletGenerator.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/generators/HandshakeWalletGenerator.java
@@ -93,7 +93,7 @@ public class HandshakeWalletGenerator extends WalletGenerator {
         unencodedAddressWithWitness[0] = WITNESS_VERSION;
         System.arraycopy(unencodedAddress, 0, unencodedAddressWithWitness, 1, unencodedAddress.length);
 
-        String address = Bech32.encode(BECH32_HRP, unencodedAddressWithWitness);
+        String address = Bech32.encode(Bech32.Encoding.BECH32, BECH32_HRP, unencodedAddressWithWitness);
 
         String privKeyText = null;
         String pubKeyText = null;

--- a/core/src/main/java/com/ashelkov/owg/wallet/generators/LitecoinWalletGenerator.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/generators/LitecoinWalletGenerator.java
@@ -92,7 +92,7 @@ public class LitecoinWalletGenerator extends WalletGenerator {
         unencodedAddressWithWitness[0] = WITNESS_VERSION;
         System.arraycopy(unencodedAddress, 0, unencodedAddressWithWitness, 1, unencodedAddress.length);
 
-        String address = Bech32.encode(BECH32_HRP, unencodedAddressWithWitness);
+        String address = Bech32.encode(Bech32.Encoding.BECH32, BECH32_HRP, unencodedAddressWithWitness);
 
         String privKeyText = null;
         String pubKeyText = null;

--- a/core/src/main/java/com/ashelkov/owg/wallet/generators/WalletGenerator.java
+++ b/core/src/main/java/com/ashelkov/owg/wallet/generators/WalletGenerator.java
@@ -1,7 +1,7 @@
 package com.ashelkov.owg.wallet.generators;
 
 import com.ashelkov.owg.bip.Coin;
-import com.ashelkov.owg.wallet.ColdWallet;
+import com.ashelkov.owg.wallet.SingleCoinWallet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,11 +36,11 @@ public abstract class WalletGenerator {
     protected abstract void logWarning(String field, int val);
     protected abstract void logMissing(String field);
 
-    public abstract ColdWallet generateWallet(
+    public abstract SingleCoinWallet generateWallet(
             Integer account,
             Integer change,
             Integer index,
             int numAddresses);
 
-    public abstract ColdWallet generateDefaultWallet();
+    public abstract SingleCoinWallet generateDefaultWallet();
 }


### PR DESCRIPTION
- Remove calls to deprecated `Bech32.encode()` function
- Update the usage information in the README